### PR TITLE
Migrate to use AndroidX so that people can use more and recent plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.1.0] - March 4, 2019
+
+**BREAKING CHANGES:** Migrated to use *AndroidX*.
+
 ## [0.0.4] - February 9, 2019
 
 Upgraded to Dart 2 support and upgraded example project to match latest framework structure.

--- a/android/src/main/java/io/fluttery/flutteryaudio/AudioPlayer.java
+++ b/android/src/main/java/io/fluttery/flutteryaudio/AudioPlayer.java
@@ -3,7 +3,7 @@ package io.fluttery.flutteryaudio;
 import android.media.MediaPlayer;
 import android.os.Handler;
 import android.os.HandlerThread;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import java.io.IOException;

--- a/android/src/main/java/io/fluttery/flutteryaudio/AudioVisualizer.java
+++ b/android/src/main/java/io/fluttery/flutteryaudio/AudioVisualizer.java
@@ -2,7 +2,7 @@ package io.fluttery.flutteryaudio;
 
 import android.media.audiofx.Equalizer;
 import android.media.audiofx.Visualizer;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 public class AudioVisualizer {
 

--- a/android/src/main/java/io/fluttery/flutteryaudio/FlutteryAudioPlugin.java
+++ b/android/src/main/java/io/fluttery/flutteryaudio/FlutteryAudioPlugin.java
@@ -2,7 +2,7 @@ package io.fluttery.flutteryaudio;
 
 import android.media.MediaPlayer;
 import android.media.audiofx.Visualizer;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import java.util.Arrays;


### PR DESCRIPTION
Lot of plugins are now moving to use AndroidX, including all plugins from Google. Staying behind means you are restricted to use older versions of all of these plugins, and many more.

Migrating to AndroidX removes the barrier and **opens the gate to the free world of updated plugins**.

I am not an expert on Android, and these changes are naive updates that I thought should be enough for Android. Corrections are welcome, if any.